### PR TITLE
java.util.Random replaced with faster java.util.concurrent.ThreadLocalRandom

### DIFF
--- a/drasyl-core/src/main/java/org/drasyl/util/RandomUtil.java
+++ b/drasyl-core/src/main/java/org/drasyl/util/RandomUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Heiko Bornholdt and Kevin Röbert
+ * Copyright (c) 2020-2023 Heiko Bornholdt and Kevin Röbert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
  */
 package org.drasyl.util;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.drasyl.util.Preconditions.requireNonNegative;
 
@@ -30,7 +30,6 @@ import static org.drasyl.util.Preconditions.requireNonNegative;
  */
 public final class RandomUtil {
     private static final char[] ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz".toCharArray();
-    private static final Random RANDOM = new Random();
 
     private RandomUtil() {
         // util class
@@ -53,7 +52,7 @@ public final class RandomUtil {
             return min;
         }
         else {
-            return RANDOM.nextInt(max - min + 1) + min;
+            return ThreadLocalRandom.current().nextInt(min, max + 1);
         }
     }
 
@@ -84,7 +83,7 @@ public final class RandomUtil {
             return min;
         }
         else {
-            return min + (long) (RANDOM.nextDouble() * (max - min + 1));
+            return ThreadLocalRandom.current().nextLong(min, max + 1);
         }
     }
 
@@ -106,7 +105,7 @@ public final class RandomUtil {
      */
     public static byte[] randomBytes(final int count) {
         final byte[] bytes = new byte[requireNonNegative(count, "count must be greater than or equal to 0")];
-        RANDOM.nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         return bytes;
     }
 
@@ -130,7 +129,7 @@ public final class RandomUtil {
         final char[] buffer = new char[requireNonNegative(length, "length must be greater than or equal to 0")];
 
         for (int i = 0; i < buffer.length; i++) {
-            buffer[i] = ALPHABET[RANDOM.nextInt(ALPHABET.length)];
+            buffer[i] = ALPHABET[ThreadLocalRandom.current().nextInt(ALPHABET.length)];
         }
 
         return new String(buffer);

--- a/drasyl-core/src/test/java/org/drasyl/util/RandomUtilTest.java
+++ b/drasyl-core/src/test/java/org/drasyl/util/RandomUtilTest.java
@@ -124,6 +124,22 @@ class RandomUtilTest {
         }
 
         @Test
+        void shouldReturnRandomNumberBetweenNonIntegers() {
+            long minResult = 2147483648L;
+            long maxResult = 4294967296L;
+            for (int i = 0; i < ITERATIONS; i++) {
+                final long result = RandomUtil.randomLong(2147483648L, 4294967296L);
+                minResult = Math.min(minResult, result);
+                maxResult = Math.max(maxResult, result);
+
+                assertThat(result, is(both(greaterThanOrEqualTo(2147483648L)).and(lessThanOrEqualTo(4294967296L))));
+            }
+
+            assertEquals(2147483648L, minResult);
+            assertEquals(4294967296L, maxResult);
+        }
+
+        @Test
         void shouldReturnMinNumberIfMinAndMaxAreEqual() {
             assertEquals(10, RandomUtil.randomLong(10, 10));
         }

--- a/drasyl-performance-tests/src/test/java/org/drasyl/util/RandomUtilBenchmark.java
+++ b/drasyl-performance-tests/src/test/java/org/drasyl/util/RandomUtilBenchmark.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020-2023 Heiko Bornholdt and Kevin Röbert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.drasyl.util;
+
+import org.drasyl.AbstractBenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Fork(1)
+@Warmup(iterations = 1)
+@Measurement(iterations = 1)
+@State(Scope.Benchmark)
+public class RandomUtilBenchmark extends AbstractBenchmark {
+    @Benchmark
+    @Threads(Threads.MAX)
+    @BenchmarkMode(Mode.Throughput)
+    public void randomIntMaxThreads(final Blackhole blackhole) {
+        blackhole.consume(RandomUtil.randomInt(10, 100));
+    }
+
+    @Benchmark
+    @Threads(1)
+    @BenchmarkMode(Mode.Throughput)
+    public void randomIntSingleThread(final Blackhole blackhole) {
+        blackhole.consume(RandomUtil.randomInt(10, 100));
+    }
+}


### PR DESCRIPTION
```plain
Benchmark                                      Mode  Cnt           Score          Error  Units
RandomUtilBenchmark.randomIntMaxThreadsOld    thrpt   25     9511753,968 ±  2021013,703  ops/s
RandomUtilBenchmark.randomIntMaxThreadsNew    thrpt   25  2833644021,612 ± 47005700,341  ops/s
RandomUtilBenchmark.randomIntSingleThreadOld  thrpt   25   135781417,949 ±   980776,361  ops/s
RandomUtilBenchmark.randomIntSingleThreadNew  thrpt   25   277421707,430 ±  3313145,991  ops/s
```