### PR TITLE
Revert "Bump org.graalvm.buildtools:native-maven-plugin from 0.9.24 to 0.9.27"

### DIFF
--- a/drasyl-shared-library/pom.xml
+++ b/drasyl-shared-library/pom.xml
@@ -63,7 +63,7 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
-                        <version>0.9.27</version>
+                        <version>0.9.24</version>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
Reverts drasyl/drasyl#504