### PR TITLE
Add support for SO_REUSEPORT for multithreaded message processing 

### DIFF
--- a/drasyl-cli/pom.xml
+++ b/drasyl-cli/pom.xml
@@ -43,6 +43,13 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <version>4.1.85.Final</version>
+            <classifier>osx-x86_64</classifier>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>drasyl-plugin-groups-manager</artifactId>
             <version>${project.version}</version>

--- a/drasyl-cli/src/main/java/org/drasyl/cli/UdpReceiver.java
+++ b/drasyl-cli/src/main/java/org/drasyl/cli/UdpReceiver.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020-2022 Heiko Bornholdt and Kevin Röbert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.drasyl.cli;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.kqueue.KQueueDatagramChannel;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.util.ReferenceCountUtil;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.LongAdder;
+
+import static io.netty.channel.unix.UnixChannelOption.SO_REUSEPORT;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class UdpReceiver {
+    public static void main(String[] args) {
+        final InetSocketAddress address = new InetSocketAddress("0.0.0.0", 10_000);
+        final int count = 2;
+
+        final EventLoopGroup group = new KQueueEventLoopGroup();
+        try {
+            for (int i = 0; i < count; i++) {
+                final Channel channel = new Bootstrap()
+                        .option(SO_REUSEPORT, true)
+                        .group(group)
+                        .channel(KQueueDatagramChannel.class)
+                        .handler(new ChannelInitializer<>() {
+                            @Override
+                            protected void initChannel(Channel ch) {
+                                ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                                    private final LongAdder adder = new LongAdder();
+
+                                    @Override
+                                    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                                        super.channelActive(ctx);
+
+                                        ctx.channel().eventLoop().scheduleAtFixedRate(() -> {
+                                            System.out.println(ctx.channel() + " " + adder.sum());
+                                        }, 5_000, 5_000, MILLISECONDS);
+                                    }
+
+                                    @Override
+                                    public void channelRead(ChannelHandlerContext ctx,
+                                                            Object msg) {
+                                        adder.increment();
+                                        ReferenceCountUtil.release(msg);
+                                    }
+                                });
+                            }
+                        })
+                        .bind(address).syncUninterruptibly().channel();
+                System.out.println("UdpReceiver.main " + channel);
+            }
+
+            while (true) {
+            }
+        }
+        finally {
+            group.shutdownGracefully().awaitUninterruptibly();
+        }
+    }
+}

--- a/drasyl-cli/src/main/java/org/drasyl/cli/UdpSender.java
+++ b/drasyl-cli/src/main/java/org/drasyl/cli/UdpSender.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020-2022 Heiko Bornholdt and Kevin Röbert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.drasyl.cli;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.kqueue.KQueueDatagramChannel;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.socket.DatagramPacket;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.LongAdder;
+
+import static org.drasyl.util.RandomUtil.randomBytes;
+
+public class UdpSender {
+    public static void main(String[] args) {
+        final InetSocketAddress address = new InetSocketAddress("127.0.0.1", 10_000);
+        final int count = 10;
+
+        final EventLoopGroup group = new KQueueEventLoopGroup();
+        try {
+            for (int i = 0; i < count; i++) {
+                final Channel channel = new Bootstrap()
+                        .group(group)
+                        .channel(KQueueDatagramChannel.class)
+                        .handler(new ChannelInitializer<>() {
+                            @Override
+                            protected void initChannel(Channel ch) {
+                                ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                                    private final LongAdder adder = new LongAdder();
+                                    private DatagramPacket msg;
+
+                                    @Override
+                                    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                                        super.channelActive(ctx);
+
+//                                        ctx.channel().eventLoop().scheduleAtFixedRate(() -> {
+//                                            System.out.println(ctx.channel() + " " + adder.sum());
+//                                        }, 5_000, 5_000, MILLISECONDS);
+
+                                        final ByteBuf buf = ctx.alloc().buffer(1000).writeBytes(randomBytes(1400));
+                                        msg = new DatagramPacket(buf, address);
+
+                                        while (ch.isWritable()) {
+//                                            adder.increment();
+                                            ctx.writeAndFlush(msg.retain());
+                                        }
+                                    }
+
+                                    @Override
+                                    public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+                                        super.channelWritabilityChanged(ctx);
+
+                                        while (ch.isWritable()) {
+//                                            adder.increment();
+                                            ctx.writeAndFlush(msg.retain());
+                                        }
+                                    }
+                                });
+                            }
+                        })
+                        .bind(0).syncUninterruptibly().channel();
+                System.out.println("UdpSender.main " + channel);
+            }
+
+            while (true) {
+            }
+        }
+        finally {
+            group.shutdownGracefully().awaitUninterruptibly();
+        }
+    }
+}


### PR DESCRIPTION
Currently we can only use one channel and therefore one thread to send or receive packets via UDP. `SO_REUSEPORT` would allow us to create multiple channels/threads and then process messages in parallel.

This pull request serves to evaluate this functionality.

## Findings so far:
* `SO_REUSEPORT` only works in conjunction with kqueue/epoll.
* Under macOS 13.7 there seems to be no load-balancing of messages. I started two process of `UdpReceiver` and `UdpSender`, each with one Channel. All messages are sent to the first receiver channel until it is closed. Only then are messages sent to the second channel. This means that `SO_REUSEPORT` would not give us any advantage under macOS.